### PR TITLE
minor performance improvement when determining max streak size

### DIFF
--- a/src/review_heatmap/activity.py
+++ b/src/review_heatmap/activity.py
@@ -100,8 +100,7 @@ class ActivityReporter(object):
                 next_timestamp = None
 
             if timestamp + 86400 != next_timestamp:  # >1 day gap. streak over.
-                if current > streak_max:
-                    streak_max = current
+                streak_max = max(current, streak_max)
                 current = 0
 
             total += activity


### PR DESCRIPTION
#### Description

Changed 

``` python
if current >  streak_max:
   streak_max = current
```

to 
```python
streak_max = max(streak_max, current)
```

[improving performance.](https://stackoverflow.com/questions/44607503/why-does-maxiterable-perform-much-slower-than-an-equivalent-loop)

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
