### PR TITLE
Option for user to stop streaks from being broken on days when there are no cards due

### DIFF
--- a/src/review_heatmap/_version.py
+++ b/src/review_heatmap/_version.py
@@ -33,4 +33,4 @@
 Version information
 """
 
-__version__ = "1.0.0-beta.1"
+__version__ = "1.0.0-beta.2"

--- a/src/review_heatmap/config.py
+++ b/src/review_heatmap/config.py
@@ -88,6 +88,7 @@ config_defaults = {
         "limhist": 0,
         "limfcst": 0,
         "limcdel": False,
+        "inclnondues": False,
         "limdecks": [],
         "version": ADDON.VERSION,
     },

--- a/src/review_heatmap/gui/options.py
+++ b/src/review_heatmap/gui/options.py
@@ -85,6 +85,7 @@ class RevHmOptions(OptionsDialog):
             ),
         ),
         ("form.cbLimDel", (("value", {"dataPath": "synced/limcdel"}),)),
+        ("form.cbInclNonDues", (("value", {"dataPath": "synced/inclnondues"}),)),
         ("form.keyGrabToggle", (("value", {"dataPath": "profile/hotkeys/toggle"}),)),
         (
             "form.listDecks",


### PR DESCRIPTION
#### Description

From issue #129, one feature request has been that if 0 cards were due on a particular day, the streak should continue, I've made an option for this in the settings so users can have this feature enabled if they do so wish (it is disabled by default).  


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
