### PR TITLE
Removed workaround for list comprehensions

### DIFF
--- a/src/review_heatmap/heatmap.py
+++ b/src/review_heatmap/heatmap.py
@@ -60,16 +60,12 @@ class HeatmapCreator(object):
         "rh-col20",
     )
 
-    # workaround for list comprehensions not working in class-scope
-    def compress_levels(colors, indices):
-        return [colors[i] for i in indices]
-
     stat_levels = {
         # tuples of threshold value, css_colors index
         "streak": list(
             zip(
                 (0, 14, 30, 90, 180, 365),
-                compress_levels(css_colors, (0, 2, 4, 6, 9, 10)),
+                map(lambda i: css_colors[i], (0, 2, 4, 6, 9, 10))
             )
         ),
         "percentage": list(zip((0, 25, 50, 60, 70, 80, 85, 90, 95, 99), css_colors)),


### PR DESCRIPTION
Removed workaround for list comprehensions not working in class-scope

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: ArchLinux (Qt 5.15.2, Kernel 5.14.14-arch1-1 64-bit)
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
