### PR TITLE
Add context to stdHtml on Overview._renderPage() for use in gui_hooks

### DIFF
--- a/src/review_heatmap/views.py
+++ b/src/review_heatmap/views.py
@@ -137,6 +137,7 @@ def overviewRenderPage(self):
         ),
         css=["overview.css"],
         js=["jquery.js", "overview.js"],
+        context=self,
     )
 
 


### PR DESCRIPTION
#### Description

As of now the hooks of `webview_will_set_content` for instance, returns a context of type `None` after navigating to the Overview webview. Adding the line of 140 would simply fix this bug.

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
