### PR TITLE
Fix crash due to deprecation of collections in python 3.10

### DIFF
--- a/src/review_heatmap/libaddon/gui/basic/interface.py
+++ b/src/review_heatmap/libaddon/gui/basic/interface.py
@@ -45,7 +45,7 @@ UIs.
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
-from collections import MutableSequence, MutableSet, MutableMapping
+from collections.abc import MutableSequence, MutableSet, MutableMapping
 
 from ...utils import getNestedAttribute
 from ...platform import PYTHON3


### PR DESCRIPTION


#### Description

DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

This correctly imports from collections.abc


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [X] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [X] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [X] I've tested my changes on at least one of the following platforms:
  - [X] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [X] AnkiDroid, version:
  - [X] AnkiWeb
