### PR TITLE
[149] Do not attempt to require d3

### DIFF
--- a/src/web/_vendor/cal-heatmap.js
+++ b/src/web/_vendor/cal-heatmap.js
@@ -8,7 +8,7 @@
  *  Contributors: gakada, Srdjan Prpa
   */
 
-var d3 = typeof require === "function" ? require("d3") : window.d3;
+var d3 = window.d3;
 
 export var CalHeatMap = function() {
 	"use strict";


### PR DESCRIPTION
Node.js' require conflicts with Anki's native require() which add-ons like Stats Plus expose in the main web view.

Since cal-heatmap uses the window.d3 global anyway within the context of Anki, dropping this should have no unintended side-effects.

In the future we might want to switch to ES6 imports, but that will likely require upgrading cal-heatmap.

Fixes #149
