### PR TITLE
Update link to ankiweb page for author's add-ons

### DIFF
--- a/src/review_heatmap/libaddon/gui/dialog_contrib.py
+++ b/src/review_heatmap/libaddon/gui/dialog_contrib.py
@@ -97,4 +97,4 @@ class ContribDialog(BasicDialog):
             return openLink(url)
         protocol, cmd = url.split("://")
         if cmd == "installed-addons":
-            openLink("https://ankiweb.net/shared/byauthor/1771074083")
+            openLink("https://ankiweb.net/shared/by-author/1771074083")


### PR DESCRIPTION
#### Description

There is a link in the support dialog supposed to open the ankiweb page, listing all your add-ons, which assumingly changed over time. This now is the corrected version.

Thanks for your great work!

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
